### PR TITLE
Complete brewery index styling

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -31,3 +31,25 @@
     text-emphasis: bold;
     color: white;
   }
+
+  .card{
+    background-color: #740001
+  }
+  .card-image{
+    background-color: #740001;
+  }
+
+  .index_banner{
+    background-color: #740001;
+    text-align: center;
+    margin-left: 40px;
+    margin-right: 40px;
+  }
+  .card-image{
+    max-height: 100%;
+  }
+  .center-cols > .col {
+    float: none;
+    display: inline-block;
+    text-align: initial;
+  }

--- a/app/views/breweries/index.html.erb
+++ b/app/views/breweries/index.html.erb
@@ -1,34 +1,20 @@
-<h1>Breweries</h1>
-<table id='brewery_list'>
-  <th>
-    <td>
-      Image
-    </td>
-    <td>
-      Name
-    </td>
-    <td>
-      Description
-    </td>
-    <td>
-      Website
-    </td>
-
-  </th>
-  <% @breweries.each do |brewery| %>
-    <tr id='brewery_instance'>
-      <td id='brewery_image'>
-        <%= brewery.image %>
-      </td>
-      <td id='brewery_name'>
-        <%= brewery.name %>
-      </td>
-      <td id='brewery_description'>
-        <%= brewery.description %>
-      </td>
-      <td id='brewery_website'>
-        <%= brewery.website %>
-      </td>
-    </tr>
-  <% end %>
-</table>
+<div class='index_banner'>
+  <h1>Breweries</h1>
+</div>
+    <div class="row center-cols center-align" id='brewery_list'>
+      <% @breweries.each do |brewery| %>
+        <div class="col m5">
+          <div class="card" id='brewery_instance'>
+            <div class="card-image" id='brewery_image'>
+              <img src="<%= brewery.image %>">
+            </div>
+            <div class="card-content" id='brewery_name'>
+              <h5><%= brewery.name %></h5>
+            </div>
+            <div class="card-action">
+              <a href="<%= brewery.website %>" id='brewery_website'>Check out their Website</a>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>

--- a/spec/features/breweries/user_views_breweries_spec.rb
+++ b/spec/features/breweries/user_views_breweries_spec.rb
@@ -13,7 +13,6 @@ feature 'user visits brewery index' do
     within all('#brewery_instance').first do
       expect(page).to have_selector('#brewery_image')
       expect(page).to have_selector('#brewery_name')
-      expect(page).to have_selector('#brewery_description')
       expect(page).to have_selector('#brewery_website')
     end
     end


### PR DESCRIPTION
Adds styling to brewery index. Each brewery is an image
card with the brewery image, name, and a link to their
website. The description was removed from this page to
prevent redundancy between index and show as well as
due to severe inconsistencies between the length/presence
of a description for each brewery. Test was modified to
accomodate this change. All tests currently passing.
Test coverage at 99.08%
Closes #17 