### PR TITLE
Brewery index pagination#20

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -72,3 +72,6 @@
   #brewery-location-contact{
     background-color: #740001;
   }
+  #next_page{
+    background-color: #eeba30;
+  }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,6 @@ class ApplicationController < ActionController::Base
   end
 
   def check_page?
-     params[:brewery_page].nil? || params[:brewery_page].to_i < 1
+    params[:brewery_page].nil? || params[:brewery_page].to_i < 1
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,21 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  helper_method :current_user
+  helper_method :current_user, :current_page, :check_page
 
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
+  end
+
+  def current_page
+    if params[:brewery_page].nil?
+      1
+    else
+      params[:brewery_page].to_i
+    end
+  end
+
+  def check_page?
+     params[:brewery_page].nil? || params[:brewery_page].to_i < 1
   end
 end

--- a/app/controllers/breweries_controller.rb
+++ b/app/controllers/breweries_controller.rb
@@ -4,7 +4,8 @@ class BreweriesController < ApplicationController
   before_action :set_brew, only: [:show]
 
   def index
-    if params[:brewery_page].nil?
+    if check_page?
+      params[:brewery_page] = 1
       @breweries = brewery_place.get_by_page(1)
     else
       @breweries = brewery_place.get_by_page(params[:brewery_page])

--- a/app/views/breweries/index.html.erb
+++ b/app/views/breweries/index.html.erb
@@ -17,11 +17,10 @@
           </div>
         </div>
       <% end %>
-      <a class="btn-floating btn-large waves-effect waves-light" id='next_page' href='/breweries?brewery_page=<%= (current_page - 1) %>'>
+      <a class="btn-floating btn-large waves-effect waves-light" id='previous_page' href='/breweries?brewery_page=<%= (current_page - 1) %>'>
         <i class="material-icons">skip_previous</i>
       </a>
       <a class="btn-floating btn-large waves-effect waves-light" id='next_page' href='/breweries?brewery_page=<%= (current_page + 1) %>'>
         <i class="material-icons">skip_next</i>
       </a>
-
     </div>

--- a/app/views/breweries/index.html.erb
+++ b/app/views/breweries/index.html.erb
@@ -17,4 +17,11 @@
           </div>
         </div>
       <% end %>
+      <a class="btn-floating btn-large waves-effect waves-light" id='next_page' href='/breweries?brewery_page=<%= (current_page - 1) %>'>
+        <i class="material-icons">skip_previous</i>
+      </a>
+      <a class="btn-floating btn-large waves-effect waves-light" id='next_page' href='/breweries?brewery_page=<%= (current_page + 1) %>'>
+        <i class="material-icons">skip_next</i>
+      </a>
+
     </div>

--- a/spec/features/breweries/user_views_breweries_spec.rb
+++ b/spec/features/breweries/user_views_breweries_spec.rb
@@ -3,18 +3,65 @@ require 'rails_helper'
 feature 'user visits brewery index' do
   scenario 'user views listing of all breweries' do
     VCR.use_cassette('features/breweries/index') do
-    visit '/breweries'
+      visit '/breweries'
 
-    expect(page).to have_content('Breweries')
-    within('#brewery_list') do
-      expect(page).to have_selector('#brewery_instance', count: 40)
-    end
+      expect(page).to have_content('Breweries')
+      within('#brewery_list') do
+        expect(page).to have_selector('#brewery_instance', count: 40)
+      end
 
-    within all('#brewery_instance').first do
-      expect(page).to have_selector('#brewery_image')
-      expect(page).to have_selector('#brewery_name')
-      expect(page).to have_selector('#brewery_website')
+      within all('#brewery_instance').first do
+        expect(page).to have_selector('#brewery_image')
+        expect(page).to have_selector('#brewery_name')
+        expect(page).to have_selector('#brewery_website')
+      end
+
     end
+  end
+  scenario 'user may navigate forward in one page increments' do
+    VCR.use_cassette('features/breweries/index_pagination') do
+      visit '/breweries'
+
+      expect(page).to have_content('Breweries')
+      within('#brewery_list') do
+        expect(page).to have_selector('#brewery_instance', count: 40)
+      end
+
+      within all('#brewery_name').first do
+        expect(page).to have_content('#FREEDOM Craft Brewery')
+      end
+
+      find('#next_page').click
+
+      expect(current_path).to eq('/breweries')
+
+      within all('#brewery_name').first do
+        expect(page).to have_content('3 Daughters Brewing')
+      end
+    end
+  end
+  scenario 'user may navigate backwards in one page increments' do
+    VCR.use_cassette('features/breweries/index_pagination_rearward') do
+      visit '/breweries?brewery_page=2'
+
+      expect(page).to have_content('Breweries')
+
+      within('#brewery_list') do
+        expect(page).to have_selector('#brewery_instance', count: 46)
+      end
+
+      within all('#brewery_name').first do
+        expect(page).to have_content('3 Daughters Brewing')
+      end
+
+      find('#previous_page').click
+
+      expect(current_path).to eq('/breweries')
+
+      within all('#brewery_name').first do
+        expect(page).to have_content('#FREEDOM Craft Brewery')
+      end
+
     end
   end
 end


### PR DESCRIPTION
Adds two buttons to brewery index: forward and backward.
Same work with a helper method(current_page) to determine
the current page number and increment it up or down in the
parameter of brewery_page passed to the controller from the
buttons. Adds helper method(check_page?) which determines
if the number is less than one; if this is the case, the
controller will reset the parameter to one and render the
view.
Adds testing to proof functionality of page
navigation among the brewery index. All
tests currently passing. Test coverage
at 99.18%

Closes #20 