### PR TITLE
Styling clean#28

### DIFF
--- a/app/assets/javascripts/search.js.erb
+++ b/app/assets/javascripts/search.js.erb
@@ -39,4 +39,5 @@ $(document).ready(function(){
   $('form').on('submit', function(event){
     event.preventDefault();
   });
+  
 });

--- a/app/assets/javascripts/search.js.erb
+++ b/app/assets/javascripts/search.js.erb
@@ -34,10 +34,9 @@ var BrewerySearch = function(){
 $(document).ready(function(){
 
   $('button[name=brewery-search]').on('click', BrewerySearch)
-  BrewerySearch();
 
   $('form').on('submit', function(event){
     event.preventDefault();
   });
-  
+
 });

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -11,7 +11,6 @@
 
   #welcome_jumbotron{
     background-color: #740001;
-    color: white;
   }
   #welcome_card{
     background-color: #740001;
@@ -19,7 +18,6 @@
   }
   #navbar{
     background-color: #eeba30;
-    color: black;
   }
   #twitter_login_button{
     background-color: #740001
@@ -97,5 +95,4 @@
   }
   #breweries_link .a{
     background-color: #740001;
-    color: black;
   }

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -90,3 +90,6 @@
   #brewery_search_submit{
     background-color: #eeba30;
   }
+  #brew_banner{
+    background-color: #eeba30
+  }

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -10,14 +10,16 @@
   }
 
   #welcome_jumbotron{
-    background-color: #ae0001;
+    background-color: #740001;
+    color: white;
   }
   #welcome_card{
     background-color: #740001;
     font-size: 18px;
   }
   #navbar{
-    background-color: #eeba30
+    background-color: #eeba30;
+    color: black;
   }
   #twitter_login_button{
     background-color: #740001
@@ -92,4 +94,8 @@
   }
   #brew_banner{
     background-color: #eeba30
+  }
+  #breweries_link .a{
+    background-color: #740001;
+    color: black;
   }

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -96,3 +96,6 @@
   #breweries_link .a{
     background-color: #740001;
   }
+  #previous_page{
+    background-color: #740001;
+  }

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -57,11 +57,18 @@
     background-color: #740001;
     padding-bottom: 0;
     margin-bottom: 0;
+    padding-right: 0;
+    padding-left: 0;
+    margin-right: 0;
+    margin-left: 0;
+    margin-top: 0;
+    padding-top: 0;
+    height: 256px;
   }
   #brewery_description{
     align-self: right;
     background-color: #740001;
-    height:262px;
+    height:256px;
   }
   #brewery_p{
     vertical-align: center;

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -3,10 +3,11 @@
       <a href="/" class="brand-logo center">BURRP</a>
       <ul class="right hide-on-med-and-down">
         <% if current_user.nil? %>
-          <li><a id='twitter_login_button' class="waves-effect waves-light btn" href='/auth/twitter'>Login with Twitter</a></li>
+          <li><a id='twitter_login_button' href='/auth/twitter'>Login with Twitter</a></li>
         <% else %>
           <li id='search_link'><a href="/search">Search</a></li>
-          <li><a id='twitter_logout_button' class="waves-effect waves-light btn" href='/logout'>Logout</a></li>
+          <li id='breweries_link' color='black'><a href='/breweries'>Breweries</a></li>
+          <li  id='twitter_logout_button'><a href='/logout'>Logout</a></li>
         <% end %>
       </ul>
     </div>

--- a/app/views/breweries/index.html.erb
+++ b/app/views/breweries/index.html.erb
@@ -1,10 +1,10 @@
-<div class='index_banner'>
+<div class='index_banner white-text'>
   <h1>Breweries</h1>
 </div>
       <% @breweries.each do |brewery| %>
         <div class="row center-cols center-align" id='brewery_instance'>
           <div class="col m7">
-            <div class="card">
+            <div class="card white-text">
               <div class="card-image" id='brewery_image'>
                 <a href='/breweries/<%= brewery.id %>'><img src="<%= brewery.image %>"> </a>
               </div>
@@ -21,6 +21,6 @@
       <a class="btn-floating btn-large waves-effect waves-light" id='previous_page' href='/breweries?brewery_page=<%= (current_page - 1) %>'>
         <i class="material-icons">skip_previous</i>
       </a>
-      <a class="btn-floating btn-large waves-effect waves-light" id='next_page' href='/breweries?brewery_page=<%= (current_page + 1) %>'>
+      <a class="btn-floating btn-large waves-effect waves-light right" id='next_page' href='/breweries?brewery_page=<%= (current_page + 1) %>'>
         <i class="material-icons">skip_next</i>
       </a>

--- a/app/views/breweries/show.html.erb
+++ b/app/views/breweries/show.html.erb
@@ -12,19 +12,22 @@
       </div>
   </div>
   <div class='row' id='contact-row'>
-    <div class='col m5' id='brewery-location-contact'>
-      <div text-align='center'>
-        <%= @brewery.street %></br>
+    <div class='col m12' id='brewery-location-contact'>
+        <%= @brewery.street %>
         <%= @brewery.city %> <%= @brewery.state %>
-        <%= @brewery.phone %></br>
-        <a href='<%= @brewery.website %>'>Visit Brewery Website</a>
-      </div>
+        <%= @brewery.phone %>
+        <a href='<%= @brewery.website %>' class='right'>Visit Brewery Website</a>
     </div>
   </div>
 </div>
+<div class='row center-cols center-align' >
+  <div class='col m7'id='brew_banner'>
+    <h4 align='center'>Brews at this Brewery</h4>
+  </div>
+</div>
 <div class="row center-cols center-align" id='brewery_list'>
+  <div class="col m5">
   <% @brews.each do |brew| %>
-    <div class="col m5">
       <div class="card" id='brew_instance'>
         <div class="card-content" id='brew_name'>
           <span class="card-title"><%= brew.name %></br>Organic: <%= brew.organic? %></span>
@@ -33,6 +36,6 @@
           </p>
         </div>
       </div>
+      <% end %>
     </div>
-  <% end %>
 </div>

--- a/app/views/breweries/show.html.erb
+++ b/app/views/breweries/show.html.erb
@@ -1,17 +1,17 @@
-<div class='index_banner'>
+<div class='index_banner white-text'>
   <h1><%= @brewery.name %></h1>
 </div>
-<div class='container'>
+<div class='container white-text'>
   <div class='row' id='brewery-show-row'>
     <div class='col m5' id='brewery_show_card'>
       <img src="<%= @brewery.image %>" id='brewery_show_image'>
     </div>
-      <div class='col m7' id='brewery_description'>
+      <div class='col m7 white-text' id='brewery_description'>
         <h4><%= @brewery.kind %></h4>
         <p id='brewery_p'><%= @brewery.description %></p>
       </div>
   </div>
-  <div class='row' id='contact-row'>
+  <div class='row white-text' id='contact-row'>
     <div class='col m12' id='brewery-location-contact'>
         <%= @brewery.street %>
         <%= @brewery.city %> <%= @brewery.state %>
@@ -22,13 +22,13 @@
 </div>
 <div class='row center-cols center-align' >
   <div class='col m7'id='brew_banner'>
-    <h4 align='center'>Brews at this Brewery</h4>
+    <h4 align='center' class='white-text'>Brews at this Brewery</h4>
   </div>
 </div>
 <div class="row center-cols center-align" id='brewery_list'>
   <div class="col m5">
   <% @brews.each do |brew| %>
-      <div class="card" id='brew_instance'>
+      <div class="card white-text" id='brew_instance'>
         <div class="card-content" id='brew_name'>
           <span class="card-title"><%= brew.name %></br>Organic: <%= brew.organic? %></span>
           <p>

--- a/app/views/search/show.html.erb
+++ b/app/views/search/show.html.erb
@@ -27,6 +27,11 @@
       </div>
     </div>
 </div>
+<div class='row center-cols center-align white-text' id='contact-row'>
+  <div class='col m7' id='brewery-location-contact'>
+    <h3 align='center'>Search Results</h3>
+  </div>
+</div>
 <div id='search-results'>
 
 </div>

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -1,5 +1,4 @@
 <div class='container'>
-
     <div class="row">
       <div class="col s12 m12">
         <div class="card-panel" id='welcome_jumbotron'>
@@ -12,7 +11,6 @@
     </div>
 </div>
 <div class='container'>
-
   <div class="row" id='welcome_cards'>
     <div class="col s6 m4">
       <div class="card-panel white-text" id='welcome_card'>

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -3,11 +3,9 @@
     <div class="row">
       <div class="col s12 m12">
         <div class="card-panel" id='welcome_jumbotron'>
-          <span class="center black-text">
+          <span class="center white-text">
             <h3>Welcome to BURRP!</h3>
-            <h6>Brewery Users Research and Remembering Point</h6>
-            <p><strong>Sign in with Facebook below</strong></p>
-            <div class="center">space for facebook login button</div>
+            <h6>Brewery Users Research and Relaxation Point</h6>
           </span>
         </div>
       </div>
@@ -17,7 +15,7 @@
 
   <div class="row" id='welcome_cards'>
     <div class="col s6 m4">
-      <div class="card-panel" id='welcome_card'>
+      <div class="card-panel white-text" id='welcome_card'>
         <div class='card-image'>
           <img src='https://encrypted-tbn2.gstatic.com/images?q=tbn:ANd9GcRIsYQkAdhULK8ctUBGOtxB5h-M_VYUnv14qX-_mLw-8p41NHPO' />
         </div>
@@ -25,7 +23,7 @@
       </div>
     </div>
     <div class="col s6 m4">
-      <div class="card-panel" id='welcome_card'>
+      <div class="card-panel white-text" id='welcome_card'>
         <div class='card-image'>
           <img src='https://encrypted-tbn2.gstatic.com/images?q=tbn:ANd9GcRIsYQkAdhULK8ctUBGOtxB5h-M_VYUnv14qX-_mLw-8p41NHPO' />
         </div>
@@ -33,7 +31,7 @@
       </div>
     </div>
     <div class="col s6 m4">
-      <div class="card-panel" id='welcome_card'>
+      <div class="card-panel white-text" id='welcome_card'>
         <div class='card-image'>
           <img src='https://encrypted-tbn2.gstatic.com/images?q=tbn:ANd9GcRIsYQkAdhULK8ctUBGOtxB5h-M_VYUnv14qX-_mLw-8p41NHPO' />
         </div>

--- a/spec/features/root/user_visits_root_spec.rb
+++ b/spec/features/root/user_visits_root_spec.rb
@@ -7,8 +7,7 @@ feature 'user visits root' do
     expect(page).to have_selector('#welcome_jumbotron')
     within('#welcome_jumbotron') do
       expect(page).to have_content('Welcome to BURRP!')
-      expect(page).to have_content('Sign in with Facebook below')
-      expect(page).to have_content('Brewery Users Research and Remembering Point')
+      expect(page).to have_content('Brewery Users Research and Relaxation Point')
     end
 
     expect(page).to have_selector('#welcome_card', count: 3)


### PR DESCRIPTION
Brews will be displayed in a single column as
breweries are on brewery index. Reformatted
#brewery-location-contact to be the same
length as the #brewery-show-row and aligned
the linkt to the website to the right of this div.
Adds a banner above #brew_list with an h4
identifying the below contents as the brews for
that brewery.Changes all text to white for readability purposes.
Removes placeholder for facebook login. Page looks a
lot brighter and much more welcoming now.
Changes text color on brewery index cards to white.
Positions buttons in appropriate locations(left and
right at bottom of page). Add search results
header to above search results on brewery
search page. Modify test to pass that was failing 
due to changed content on root.